### PR TITLE
[Hotfix] add param "block" for protocol_config function

### DIFF
--- a/pkg/client/protocol.go
+++ b/pkg/client/protocol.go
@@ -2,11 +2,13 @@ package client
 
 import (
 	"context"
+
+	"github.com/eteu-technologies/near-api-go/pkg/client/block"
 )
 
 // https://docs.near.org/api/rpc/protocol#protocol-config
-func (c *Client) ProtocolConfig(ctx context.Context) (res map[string]interface{}, err error) {
-	_, err = c.doRPC(ctx, &res, "EXPERIMENTAL_protocol_config", nil, nil)
+func (c *Client) ProtocolConfig(ctx context.Context, block block.BlockCharacteristic) (res map[string]interface{}, err error) {
+	_, err = c.doRPC(ctx, &res, "EXPERIMENTAL_protocol_config", block, map[string]interface{}{})
 
 	return
 }


### PR DESCRIPTION
Hi, I just added a param "block" into ProtocolConfig function. Please review and merge for me, thank you so much!
The unit test works fine:
![image](https://user-images.githubusercontent.com/4811620/183623097-ab97408d-60b0-4563-9768-8897a4544019.png)

