### PR TITLE
Export prepareTransaction func

### DIFF
--- a/pkg/client/transaction_wrapper.go
+++ b/pkg/client/transaction_wrapper.go
@@ -20,7 +20,7 @@ type transactionCtx struct {
 
 type TransactionOpt func(context.Context, *transactionCtx) error
 
-func (c *Client) prepareTransaction(ctx context.Context, from, to types.AccountID, actions []action.Action, txnOpts ...TransactionOpt) (ctx2 context.Context, blob string, err error) {
+func (c *Client) PrepareTransaction(ctx context.Context, from, to types.AccountID, actions []action.Action, txnOpts ...TransactionOpt) (ctx2 context.Context, blob string, err error) {
 	ctx2 = context.WithValue(ctx, clientCtx, c)
 	txn := transaction.Transaction{
 		SignerID:   from,
@@ -67,7 +67,7 @@ func (c *Client) prepareTransaction(ctx context.Context, from, to types.AccountI
 
 // https://docs.near.org/docs/api/rpc#send-transaction-async
 func (c *Client) TransactionSend(ctx context.Context, from, to types.AccountID, actions []action.Action, txnOpts ...TransactionOpt) (res hash.CryptoHash, err error) {
-	ctx2, blob, err := c.prepareTransaction(ctx, from, to, actions, txnOpts...)
+	ctx2, blob, err := c.PrepareTransaction(ctx, from, to, actions, txnOpts...)
 	if err != nil {
 		return
 	}
@@ -76,7 +76,7 @@ func (c *Client) TransactionSend(ctx context.Context, from, to types.AccountID, 
 
 // https://docs.near.org/docs/api/rpc#send-transaction-await
 func (c *Client) TransactionSendAwait(ctx context.Context, from, to types.AccountID, actions []action.Action, txnOpts ...TransactionOpt) (res FinalExecutionOutcomeView, err error) {
-	ctx2, blob, err := c.prepareTransaction(ctx, from, to, actions, txnOpts...)
+	ctx2, blob, err := c.PrepareTransaction(ctx, from, to, actions, txnOpts...)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Hi all, thanks for your work on this API!

I believe there are many situations, including my use case, where one might want to prepare a transaction without immediately sending it. Therefore I propose to export the prepareTransaction func so it is accessible.

Kind regards